### PR TITLE
Change Tool Type to Remote

### DIFF
--- a/Reset Office 365 Key on Client.xml
+++ b/Reset Office 365 Key on Client.xml
@@ -7,7 +7,7 @@
     <SuccessCodesText>0</SuccessCodesText>
     <Timeout>00:03:00</Timeout>
     <WakeOnLan value="false" />
-    <CustomToolType>System</CustomToolType>
+    <CustomToolType>Remote</CustomToolType>
     <CommandLine>#store the license info into an array
 $license = cscript 'C:\Program Files (x86)\Microsoft Office\Office16\OSPP.VBS' /dstatus
 #license name from /dstatus


### PR DESCRIPTION
I believe this needs to be a Remote Tool. As a System Tool it will only run on the computer running PDQ Inventory.

I'm not sure why GitHub wants to add a newline at the end of the file, but it shouldn't hurt anything.